### PR TITLE
Add test/runtests.jl for automated test discovery, clean up Julia v0.4 deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
   - sudo apt-get install libpcre3-dev julia -y
 script:
   - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("BloomFilters"))`); Pkg.pin("BloomFilters"); Pkg.resolve()'
-  - julia -e 'using BloomFilters; @assert isdefined(:BloomFilters); @assert typeof(BloomFilters) === Module; include(joinpath(Pkg.dir("BloomFilters"), "tests/bloom-tests.jl"))'
+  - julia -e 'using BloomFilters; @assert isdefined(:BloomFilters); @assert typeof(BloomFilters) === Module; include(joinpath(Pkg.dir("BloomFilters"), "test/runtests.jl"))'

--- a/src/bloom-filter.jl
+++ b/src/bloom-filter.jl
@@ -15,8 +15,8 @@ end
 # which uses 2 hash functions vs. k and has comparable properties
 # See Kirsch and Mitzenmacher, 2008: http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/rsa.pdf
 function hash_n(key::Any, k::Int, max::Int)
-    a_hash = hash(key, uint(0))
-    b_hash = hash(key, uint(170))
+    a_hash = hash(key, UInt(0))
+    b_hash = hash(key, UInt(170))
     hashes = Array(Uint, k)
     for i in 1:k
         hashes[i] = mod(a_hash + i * b_hash, max) + 1
@@ -84,15 +84,15 @@ end
 # USE CASES: Recommended when extreme space efficiency is required, and modestly slower insertions
 # and lookups are tolerable.
 function BloomFilter(capacity::Int, error_rate::Float64)
-    bits_per_elem = int(ceil(-1.0 * (log(error_rate) / (log(2) ^ 2))))
-    k_hashes = int(round(log(2) * bits_per_elem))  # Note: ceil() would be strictly more conservative
+    bits_per_elem = round(Int, ceil(-1.0 * (log(error_rate) / (log(2) ^ 2))))
+    k_hashes = round(Int, log(2) * bits_per_elem)  # Note: ceil() would be strictly more conservative
     n_bits = capacity * bits_per_elem
     BloomFilter(falses((1, n_bits)), k_hashes, capacity, error_rate, n_bits, "")
 end
 
 function BloomFilter(mmap_handle::IOStream, capacity::Int, error_rate::Float64)
-    bits_per_elem = int(ceil(-1.0 * (log(error_rate) / (log(2) ^ 2))))
-    k_hashes = int(round(log(2) * bits_per_elem))  # Note: ceil() would be strictly more conservative
+    bits_per_elem = round(Int, ceil(-1.0 * (log(error_rate) / (log(2) ^ 2))))
+    k_hashes = round(Int, log(2) * bits_per_elem)  # Note: ceil() would be strictly more conservative
     n_bits = capacity * bits_per_elem
     mb = mmap_bitarray((n_bits, 1), mmap_handle)
     BloomFilter(mb, k_hashes, capacity, error_rate, n_bits, mmap_handle.name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,8 @@ try
     assert(contains(bfb, test_other_d))
     assert(contains(bfb, test_other_e))  # Check that we're hashing the value, not object ref
 
+    println("Successfully passed all tests.")
+
 finally
     # Clean up mmap-backed temp files (otherwise can end up re-opening them and writing multiple key sets to one file!)
     rm("/tmp/test_array1.array")


### PR DESCRIPTION
FYI I'm planning to merge this and tag as v0.1.0 (which we previously have not tagged, and this should be wholly backwards compatible / has no feature or API changes).