### PR TITLE
Julia 0.7/1.0/1.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-BloomFilters.jl
-===============
+# BloomFilters.jl
 
 [![Build Status](https://travis-ci.org/johnmyleswhite/BloomFilters.jl.png)](https://travis-ci.org/johnmyleswhite/BloomFilters.jl)
 
 *Please note: The API for version 0.1.0 of this package has changed substantially from version 0.0.1. Please review the below README and accompanying library documentation.*
 
-Bloom filter implementation in Julia. Supports insertion (`add!`) and probabilistic membership queries (`contains`) for sets using an in-memory or mmap'd bit array. When an element `x` is inserted into a Bloom filter, set membership queries will always correctly return `true` for `x` (i.e., there are no false negatives). Bloom filter membership queries do, however, occassionally return `true` for a `y` not inserted into the data structure (i.e., false positives are possible). With this cost comes remarkable space efficiency: Bloom filters can store set membership using only 10 bits per element at a 1.00% error rate or 20 bits per element at a 0.01% error rate. This space requirement is irrespective of the size or length of the inserted elements (e.g., one can store a set of URLs using only a handful of bits per URL).
-
+[Bloom filter](https://en.wikipedia.org/wiki/Bloom_filter) implementation in [Julia](https://julialang.org). Supports insertion (`add!`) and probabilistic membership queries (`in`) for sets using an in-memory or mmap'd bit array. When an element `x` is inserted into a Bloom filter, set membership queries will always correctly return `true` for `x` (i.e., there are no false negatives). Bloom filter membership queries do, however, occassionally return `true` for a `y` not inserted into the data structure (i.e., false positives are possible). With this cost comes remarkable space efficiency: Bloom filters can store set membership using only 10 bits per element at a 1.00% error rate or 20 bits per element at a 0.01% error rate. This space requirement is irrespective of the size or length of the inserted elements (e.g., one can store a set of URLs using only a handful of bits per URL).
 
 Forthcoming features include:
+
 * Better persistence (only the bit array is automatically saved when using the mmap-backed version; parameters must be separately stored or hard-coded)
 * Support for arbitrary numbers of hash functions (*k* > 12)
 
+## Quickstart
 
-Quickstart
-==========
 Quick functionality demo:
-```
+
+```julia
 using BloomFilters
 
 
@@ -25,8 +24,8 @@ bf = BloomFilter(1000, 0.001)  # Create an in-memory Bloom filter
 							   # expected error rate of 0.1%
 
 add!(bf, "My first element.")
-contains(bf, "My first element.")   # Returns true
-contains(bf, "My second element.")  # Returns false
+in("My first element.", bf)   # Returns true
+in("My second element.", bf)  # Returns false
 "My first element." in bf           # Returns true
 show(bf)
 
@@ -39,10 +38,9 @@ show(bf)
 
 By default, the Bloom filter will be constructed using an optimal number of k hash functions, which minimizes the expected false positive rate per required bit of storage. In many cases, however, it may be advantegous to specify a smaller value of k in order to save time hashing and performing subsequent memory accesses. Alternatively, one may want to explicitly set the number of bits to use per element _and_ k, rather than constructing the filter by passing a target error rate.
 
-
 The `BloomFilters` module supports all 3 of these patterns:
 
-```
+```julia
 # Constructor pattern #1: Pass capacity and error rate
 bf1 = BloomFilter(1000, 0.001)
 
@@ -53,10 +51,9 @@ bf2 = BloomFilter(1000, 0.001, 6)  # vs. the optimal number of 10 if not specifi
 bf3 = BloomFilter(1000, 16, 6)  # Same as bf2, but will *not* compute the error rate and display NaN when show() is called
 ```
 
-
 In addition to this, basic persistence support is provided via optionally using an mmap-backed bit array. This works with each of the above methods by either passing a string of the mmap filepath or an `IOStream`:
 
-```
+```julia
 ### With an IOStream
 # Note that "w+" needs to be passed as the second argument to open() if creating
 # a new mmap-backed Bloom filter, or "r+" if opening an already created one

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
-Compat 0.3.2
+julia 0.7
+Compat 2.0.0

--- a/src/BloomFilters.jl
+++ b/src/BloomFilters.jl
@@ -1,4 +1,11 @@
 module BloomFilters
 	export BloomFilter, add!
+	
+	if VERSION < v"1.0.0"
+		import Base: contains
+	else
+		export contains	
+	end
+
 	include("bloom-filter.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,178 +3,182 @@
 # the filter(s) will become too full and tests will fail
 using BloomFilters
 using Printf
+using Test
 
-try
-    # First set up 9 sample Bloom filters using different constructors
-    # (Ordered as in bloom-filter.jl)
-    # Raw construction
-    bf0 = BloomFilter(BitVector(undef, 10), 4, 10, 0.01, 20, "")
+@testset "BloomFilters" begin
+    try
+        # First set up 9 sample Bloom filters using different constructors
+        # (Ordered as in bloom-filter.jl)
+        # Raw construction
+        bf0 = BloomFilter(BitVector(undef, 10), 4, 10, 0.01, 20, "")
 
-    # First group of constructors: capacity, bits per element, k
-    bf1 = BloomFilter(1000, 20, 4)
-    bf2 = BloomFilter(open("/tmp/test_array1.array", "w+"), 1000, 20, 4)
-    bf3 = BloomFilter("/tmp/test_array2.array", 1000, 20, 4)
+        # First group of constructors: capacity, bits per element, k
+        bf1 = BloomFilter(1000, 20, 4)
+        bf2 = BloomFilter(open("/tmp/test_array1.array", "w+"), 1000, 20, 4)
+        bf3 = BloomFilter("/tmp/test_array2.array", 1000, 20, 4)
 
-    # Second group of constructors: capacity, error rate, k
-    bf4 = BloomFilter(1000, 0.01, 5)
-    bf5 = BloomFilter(open("/tmp/test_array3.array", "w+"), 1000, 0.01, 5)
-    bf6 = BloomFilter("/tmp/test_array4.array", 1000, 0.01, 5)
+        # Second group of constructors: capacity, error rate, k
+        bf4 = BloomFilter(1000, 0.01, 5)
+        bf5 = BloomFilter(open("/tmp/test_array3.array", "w+"), 1000, 0.01, 5)
+        bf6 = BloomFilter("/tmp/test_array4.array", 1000, 0.01, 5)
 
-    # Third group of constructors: capacity and error rate only,
-    # computes optimal k from a space efficiency perspective
-    bf7 = BloomFilter(1000, 0.01)
-    bf8 = BloomFilter(open("/tmp/test_array5.array", "w+"), 1000, 0.01)
-    bf9 = BloomFilter("/tmp/test_array6.array", 1000, 0.01)
+        # Third group of constructors: capacity and error rate only,
+        # computes optimal k from a space efficiency perspective
+        bf7 = BloomFilter(1000, 0.01)
+        bf8 = BloomFilter(open("/tmp/test_array5.array", "w+"), 1000, 0.01)
+        bf9 = BloomFilter("/tmp/test_array6.array", 1000, 0.01)
 
-    # Now create a larger in-memory Bloom filter and an mmap-backed one for testing
-    n = 100000
-    bfa = BloomFilter(n, 0.001, 5)
-    bfb = BloomFilter("/tmp/test_array_lg.array", n, 0.001, 5)
+        # Now create a larger in-memory Bloom filter and an mmap-backed one for testing
+        n = 100000
+        bfa = BloomFilter(n, 0.001, 5)
+        bfb = BloomFilter("/tmp/test_array_lg.array", n, 0.001, 5)
 
-    # Test with random strings
-    random_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-    test_keys = Array{String}(undef, n)
-    for i in 1:n
-        temp_str = ""
-        for j in 1:8
-            temp_str = string(temp_str, random_chars[rand(1:62)])
+        # Test with random strings
+        random_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        test_keys = Array{String}(undef, n)
+        for i in 1:n
+            temp_str = ""
+            for j in 1:8
+                temp_str = string(temp_str, random_chars[rand(1:62)])
+            end
+            test_keys[i] = temp_str
         end
-        test_keys[i] = temp_str
-    end
 
-    println("For insertions:")
-    @time(
-    for test_key in test_keys
-        add!(bfa, test_key)
-    end
-    )
-
-    # also test in() while we're at it.
-    println("For lookups:")
-    @time(
-    for test_key in test_keys
-        @assert(contains(bfa, test_key))
-        @assert(in(test_key,bfa))
-    end
-    )
-
-    println("For insertions (mmap-backed):")
-    @time(
-    for test_key in test_keys
-        add!(bfb, test_key)
-    end
-    )
-
-    println("For lookups (mmap-backed):")
-    @time(
-    for test_key in test_keys
-        @assert(contains(bfb, test_key))
-    end
-    )
-
-    # Test vectorized add!/contains
-    bf_vector = BloomFilter(n, 0.001, 5)
-    add!(bf_vector, test_keys)
-    @assert(all(contains(bf_vector, test_keys)))
-
-    # Test hashing non-string objects and non-string vectors
-    numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    add!(bf_vector, numbers)
-    @assert(all(contains(bf_vector, numbers)))
-
-    # Probabilistic tests – note these may fail every once in a while...
-    # (but very very rarely)
-    test_keys_p = Array{String}(undef, n)
-    for i in 1:n
-        temp_str = ""
-        for j in 1:9  # Longer so not in by definition
-            temp_str = string(temp_str, random_chars[rand(1:62)])
+        println("For insertions:")
+        @time(
+        for test_key in test_keys
+            add!(bfa, test_key)
         end
-        test_keys_p[i] = temp_str
-    end
+        )
 
-    false_positives_a = 0
-    false_positives_b = 0
-    for test_key_p in test_keys_p
-        if contains(bfa, test_key_p)
-            false_positives_a += 1
+        # also test in() while we're at it.
+        println("For lookups:")
+        @time(
+        for test_key in test_keys
+            @test_deprecated contains(bfa, test_key)
+            @test in(test_key, bfa)
         end
-        if contains(bfb, test_key_p)
-            false_positives_b += 1
+        )
+
+        println("For insertions (mmap-backed):")
+        @time(
+        for test_key in test_keys
+            add!(bfb, test_key)
         end
+        )
+
+        println("For lookups (mmap-backed):")
+        @time(
+        for test_key in test_keys
+            @test in(test_key, bfb)
+        end
+        )
+
+        # Test vectorized add!/contains
+        bf_vector = BloomFilter(n, 0.001, 5)
+        add!(bf_vector, test_keys)
+        @test all(in(test_keys, bf_vector))
+
+        # Test hashing non-string objects and non-string vectors
+        numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        add!(bf_vector, numbers)
+        @test all(in(numbers, bf_vector))
+
+        # Probabilistic tests – note these may fail every once in a while...
+        # (but very very rarely)
+        test_keys_p = Array{String}(undef, n)
+        for i in 1:n
+            temp_str = ""
+            for j in 1:9  # Longer so not in by definition
+                temp_str = string(temp_str, random_chars[rand(1:62)])
+            end
+            test_keys_p[i] = temp_str
+        end
+
+        false_positives_a = 0
+        false_positives_b = 0
+        for test_key_p in test_keys_p
+            if in(test_key_p, bfa)
+                false_positives_a += 1
+            end
+            if in(test_key_p, bfb)
+                false_positives_b += 1
+            end
+        end
+
+        # Actually include a probabilistic test case - that there are less than 1.75X the
+        # number of expected false positives (there will be > 1 50% of the time).
+        # 1.75x selected because it's hopefully low enough to catch a bug that breaks this
+        # code, but it should only actually fail by chance 1 in ~1 trillion times (i.e., not
+        # as part of an autoamted test suite).
+        @printf "System is %s-bit\n" string(typeof(1))[4:5]
+        @printf "In-memory Bloom is %.2f%% full\n" (100 * sum(bfa.array) / bfa.n_bits)
+        @printf "%d false positives in %d tests\n" false_positives_a n
+        @printf "Error rate for in-memory Bloom filter %.2f%%\n" (bfa.error_rate * 100)
+        @test (false_positives_a / n) <= (1.75 * bfa.error_rate)
+
+        @printf "Mmap'd Bloom is %.2f%% full\n" (100 * sum(bfb.array) / bfb.n_bits)
+        @printf "%d false positives in %d tests\n" false_positives_b n
+        @printf "Error rate for in-memory Bloom filter %.2f%%\n" (bfb.error_rate * 100)
+        @test (false_positives_b / n) <= (1.75 * bfb.error_rate)
+        @test false_positives_a == false_positives_b  # Must be true since bfa and bfb should be identical at bit-level
+
+        # Test re-opening bfb
+        bfb = 0
+        GC.gc()
+
+        bfb = BloomFilter(open("/tmp/test_array_lg.array", "r+"), n, 0.001, 5)
+        println("For lookups after re-opening (mmap-backed):")
+        @time(
+        for test_key in test_keys
+            @test in(test_key, bfb)
+        end
+        )
+
+        bfb = 0
+        GC.gc()
+
+        bfb = BloomFilter("/tmp/test_array_lg.array", n, 0.001, 5)
+        println("For lookups after re-opening second time (mmap-backed):")
+        @time(
+        for test_key in test_keys
+            @test in(test_key, bfb)
+        end
+        )
+
+        # Test insertions of non-string types
+        # This works in Julia 0.3+ as hash(Any, Seed) has
+        # been added to hashing.jl
+        test_other_a = 17    # Int
+        test_other_b = 15.6  # Float
+        test_other_c = "String" #("Tuples", "of", "strings")
+        test_other_d = ("Tuples", "of", "Strings")
+        test_other_e = ("Tuples", "of", "Strings")  # Not inserted
+
+        add!(bfb, test_other_a)
+        add!(bfb, test_other_b)
+        add!(bfb, test_other_c)
+        add!(bfb, test_other_d)
+
+        @test in(test_other_a, bfb)
+        @test in(test_other_b, bfb)
+        @test in(test_other_c, bfb)
+        @test in(test_other_d, bfb)
+        @test in(test_other_e, bfb)  # Check that we're hashing the value, not object ref
+
+        println("Successfully passed all tests.")
+
+    finally
+    # Clean up mmap-backed temp files (otherwise can end up re-opening them and writing multiple key sets to one file!)
+
+        rm("/tmp/test_array1.array")
+        rm("/tmp/test_array2.array")
+        rm("/tmp/test_array3.array")
+        rm("/tmp/test_array4.array")
+        rm("/tmp/test_array5.array")
+        rm("/tmp/test_array6.array")
+        rm("/tmp/test_array_lg.array")
+
     end
-
-    # Actually include a probabilistic test case - that there are less than 1.75X the
-    # number of expected false positives (there will be > 1 50% of the time).
-    # 1.75x selected because it's hopefully low enough to catch a bug that breaks this
-    # code, but it should only actually fail by chance 1 in ~1 trillion times (i.e., not
-    # as part of an autoamted test suite).
-    @printf "System is %s-bit\n" string(typeof(1))[4:5]
-    @printf "In-memory Bloom is %.2f%% full\n" (100 * sum(bfa.array) / bfa.n_bits)
-    @printf "%d false positives in %d tests\n" false_positives_a n
-    @printf "Error rate for in-memory Bloom filter %.2f%%\n" (bfa.error_rate * 100)
-    @assert((false_positives_a / n) <= (1.75 * bfa.error_rate))
-
-    @printf "Mmap'd Bloom is %.2f%% full\n" (100 * sum(bfb.array) / bfb.n_bits)
-    @printf "%d false positives in %d tests\n" false_positives_b n
-    @printf "Error rate for in-memory Bloom filter %.2f%%\n" (bfb.error_rate * 100)
-    @assert((false_positives_b / n) <= (1.75 * bfb.error_rate))
-    @assert(false_positives_a == false_positives_b)  # Must be true since bfa and bfb should be identical at bit-level
-
-    # Test re-opening bfb
-    bfb = 0
-    GC.gc()
-
-    bfb = BloomFilter(open("/tmp/test_array_lg.array", "r+"), n, 0.001, 5)
-    println("For lookups after re-opening (mmap-backed):")
-    @time(
-    for test_key in test_keys
-        @assert(contains(bfb, test_key))
-    end
-    )
-
-    bfb = 0
-    GC.gc()
-
-    bfb = BloomFilter("/tmp/test_array_lg.array", n, 0.001, 5)
-    println("For lookups after re-opening second time (mmap-backed):")
-    @time(
-    for test_key in test_keys
-        @assert(contains(bfb, test_key))
-    end
-    )
-
-    # Test insertions of non-string types
-    # This works in Julia 0.3+ as hash(Any, Seed) has
-    # been added to hashing.jl
-    test_other_a = 17    # Int
-    test_other_b = 15.6  # Float
-    test_other_c = "String" #("Tuples", "of", "strings")
-    test_other_d = ("Tuples", "of", "Strings")
-    test_other_e = ("Tuples", "of", "Strings")  # Not inserted
-
-    add!(bfb, test_other_a)
-    add!(bfb, test_other_b)
-    add!(bfb, test_other_c)
-    add!(bfb, test_other_d)
-
-    @assert(contains(bfb, test_other_a))
-    @assert(contains(bfb, test_other_b))
-    @assert(contains(bfb, test_other_c))
-    @assert(contains(bfb, test_other_d))
-    @assert(contains(bfb, test_other_e))  # Check that we're hashing the value, not object ref
-
-    println("Successfully passed all tests.")
-
-finally
-# Clean up mmap-backed temp files (otherwise can end up re-opening them and writing multiple key sets to one file!)
-
-    rm("/tmp/test_array1.array")
-    rm("/tmp/test_array2.array")
-    rm("/tmp/test_array3.array")
-    rm("/tmp/test_array4.array")
-    rm("/tmp/test_array5.array")
-    rm("/tmp/test_array6.array")
-    rm("/tmp/test_array_lg.array")
 
 end


### PR DESCRIPTION
Julia 0.7/1.0/1.1 support

Using [Test](https://docs.julialang.org/en/v1/stdlib/Test/) from stdlib
 - Uses `@testset` macro
 - changes `@assert` to `@test`

Using `in` instead of `contains`

Deprecates `contains`

Using parametric type instead of `Any`

Minor fixes to `README.md` documentation

Closes #22

Replaces #20 #23 